### PR TITLE
EDE-433: Update Studio link logic and link for course access role page

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -364,8 +364,12 @@
                 <ul>
                   <li ${'class="active"' if request.path == reverse('dashboard') else ''}><a href="${reverse('dashboard')}">Courses</a></li>
                   <li  ${'class="active"' if request.path == marketing_link('COURSES') else ''}><a href="${marketing_link('COURSES')}">Discover New</a></li>
-                  % if user.is_staff:
+                  % if user.is_staff or user.courseaccessrole_set.filter(role='course_creator_group').exists():
                     <li><a href="//${configuration_helpers.get_value('CMS_BASE')}">Studio</a></li>
+                  % endif
+
+                  % if user.is_staff or user.courseaccessrole_set.filter(role='role_manager').exists():
+                    <li><a href="//${reverse('colaraz_features:course-access-roles-list')}">Course Access Roles</a></li>
                   % endif
                 </ul>
             </div>


### PR DESCRIPTION
**Description:**
This PR contains changes as discussed in the call with Colaraz, here are the main changes
1. Update logic for displaying studio link, the link should be visible for staff and all the users with course creator group access
2. Added a link for course access role management page. The page should be visible to staff and all the users with role manager access.