### PR TITLE
EDE-504 Fix dashboard and discover new active status on sidebar

### DIFF
--- a/colaraz/cms/templates/base.html
+++ b/colaraz/cms/templates/base.html
@@ -11,6 +11,7 @@
 ## Standard imports
 <%namespace name='static' file='static_content.html'/>
 <%!
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from openedx.core.djangoapps.util.user_messages import PageLevelMessages
@@ -18,6 +19,7 @@ from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
 from openedx.core.djangolib.markup import HTML
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.release import RELEASE_LINE
 %>
 
@@ -152,30 +154,44 @@ from openedx.core.release import RELEASE_LINE
       <%block name="page_alert"></%block>
       </div>
 
+      % if user.is_authenticated:
       <main id="main" aria-label="Content" tabindex="-1">
+        <%
+          lms_base = configuration_helpers.get_value('LMS_BASE')
+          lms_dashboard_url = '{}{}'.format(lms_base, '/dashboard')
+          lms_new_courses_url = '{}{}'.format(lms_base, '/courses')
+          lms_course_privileges_url = '{}{}'.format(lms_base, reverse('colaraz_features:course-access-roles-list'))
+
+          colaraz_profile = user.colaraz_profile
+          job_title = colaraz_profile.job_title
+          profile_image_url = colaraz_profile.profile_image_url or "http://polymath.colaraz.net/cvsocial/_graphics/icons/user/defaultsmall.gif"
+          profile_strength_color = colaraz_profile.profile_strength_color
+          profile_strength_title = colaraz_profile.profile_strength_title
+          profile_strength_width = colaraz_profile.profile_strength_width
+        %>
         <div class="side-container">
           <div class="side-widget side-profile">
             <div class="side-profile-row">
               <div class="avatar">
-                <img src="${static.url('images/instructor.jpg')}" alt="User Name" title="User Name">
+                <img src="${profile_image_url}" alt="${user.profile.name}" title="${user.profile.name}">
               </div>
-              <span class="user-name">User Name</span>
-                <span class="designation">Designation</span>
+              <span class="user-name">${user.profile.name}</span>
+                <span class="designation">${job_title}</span>
             </div>
             <div id="progress" class="profile-progress-bar">
               <div class="progress progress-striped">
-              <div class="progress-bar progress-bar-striped" style="width:30%;background-color: #eb7d3c" id="progressbar">
-                  <span class="sr-only">Beginner</span>
+                  <div class="progress-bar progress-bar-striped" style="width:${profile_strength_width};background-color:${profile_strength_color}" id="progressbar">
+                  <span class="sr-only">${profile_strength_title}</span>
                 </div>
               </div>
-              <span class="progress-result">Beginner</span>
+              <span class="progress-result">${profile_strength_title}</span>
             </div>
             <div class="side-nav">
               <ul>
-                <li><a href="#">Courses</a></li>
-                <li><a href="#">Discover New</a></li>
+                <li><a href="//${lms_dashboard_url}">Courses</a></li>
+                <li><a href="//${lms_new_courses_url}">Discover New</a></li>
                 <li class="active"><a href="#">Studio</a></li>
-                <li><a href="#">Course Privileges</a></li>
+                <li><a href="//${lms_course_privileges_url}">Course Privileges</a></li>
               </ul>
             </div>
           </div>
@@ -184,6 +200,7 @@ from openedx.core.release import RELEASE_LINE
         <%block name="content"></%block>
         </div>
       </main>
+      % endif
 
       % if user.is_authenticated:
         <%include file="widgets/sock.html" args="online_help_token=online_help_token" />

--- a/colaraz/lms/templates/main.html
+++ b/colaraz/lms/templates/main.html
@@ -21,16 +21,17 @@
     from django.utils.http import urlquote_plus
     from django.utils.translation import ugettext as _
     from django.utils.translation import get_language_bidi
+    from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
     from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
     from openedx.core.release import RELEASE_LINE
-    from openedx.features.colaraz_features.models import ColarazUserProfile
     from pipeline_mako import render_require_js_path_overrides
+    from student.models import CourseEnrollment
 %>
 
 <%
     if user.is_authenticated:
-        colaraz_profile = ColarazUserProfile.objects.get(user=user)
+        colaraz_profile = user.colaraz_profile
         job_title = colaraz_profile.job_title
         profile_image_url = colaraz_profile.profile_image_url or "http://polymath.colaraz.net/cvsocial/_graphics/icons/user/defaultsmall.gif"
         profile_strength_color = colaraz_profile.profile_strength_color
@@ -362,14 +363,39 @@
             </div>
             <div class="side-nav">
                 <ul>
-                  <li ${'class="active"' if request.path == reverse('dashboard') else ''}><a href="${reverse('dashboard')}">Courses</a></li>
-                  <li  ${'class="active"' if request.path == marketing_link('COURSES') else ''}><a href="${marketing_link('COURSES')}">Discover New</a></li>
+                  <%
+                    user_enrolled = None
+                    if user.is_authenticated and hasattr(course, 'id'):
+                        course_overview = CourseOverview.objects.get(id=course.id)
+                        user_enrolled = CourseEnrollment.objects.filter(user=user,course=course_overview, is_active=True).exists()
+                    endif
+
+                    is_dashboard = None
+                    if request.path == reverse('dashboard') or user_enrolled:
+                        is_dashboard = True
+                    endif
+
+                    is_discover_new = None
+                    if request.path == marketing_link('COURSES') or not is_dashboard:
+                        is_discover_new = True
+                    endif
+
+                    is_course_privileges = None
+                    if 'course-access-roles' in request.path:
+                        is_course_privileges = True
+                    endif
+
+                    is_dashboard = is_dashboard and not is_discover_new and not is_course_privileges
+                    is_discover_new = is_discover_new and not is_course_privileges
+                  %>
+                  <li ${'class="active"' if is_dashboard else ''}><a href="${reverse('dashboard')}">Courses</a></li>
+                  <li  ${'class="active"' if is_discover_new  else ''}><a href="${marketing_link('COURSES')}">Discover New</a></li>
                   % if user.is_staff or user.courseaccessrole_set.filter(role='course_creator_group').exists():
                     <li><a href="//${configuration_helpers.get_value('CMS_BASE')}">Studio</a></li>
                   % endif
 
                   % if user.is_staff or user.courseaccessrole_set.filter(role='role_manager').exists():
-                    <li><a href="${reverse('colaraz_features:course-access-roles-list')}">Course Privileges</a></li>
+                    <li ${'class="active"' if is_course_privileges  else ''}><a href="${reverse('colaraz_features:course-access-roles-list')}">Course Privileges</a></li>
                   % endif
                 </ul>
             </div>


### PR DESCRIPTION
This PR is related to [EDE-504](https://edlyio.atlassian.net/browse/EDE-504)

**PR Description:**

The active statuses of links available in the sidebar were not working properly. For example: if we clicked on any course available on `Dashboard` or `Discover New` page, the active status on the sidebar disappeared.

This issue has been fixed in this PR.

Moreover, the active status functionality and links navigation have also been added on the studio side.


**Studio**

![image](https://user-images.githubusercontent.com/42294172/82321372-2e85ac80-99ee-11ea-9900-21d7e3732ac6.png)

**LMS Dashboard Home Page**
![image](https://user-images.githubusercontent.com/42294172/82321837-efa42680-99ee-11ea-9e41-a8084326777c.png)

**Inside a course in which the user has been enrolled**
![image](https://user-images.githubusercontent.com/42294172/82321918-14989980-99ef-11ea-9020-c7c1ba516e42.png)

**Inside a course in which the user has not been enrolled**
![image](https://user-images.githubusercontent.com/42294172/82322064-4e69a000-99ef-11ea-81c8-0d79925be003.png)
