### PR TITLE
COL-110 Fix course privileges url for studio site

### DIFF
--- a/colaraz/cms/templates/base.html
+++ b/colaraz/cms/templates/base.html
@@ -199,7 +199,7 @@ from openedx.core.release import RELEASE_LINE
                 <li><a href="//${lms_new_courses_url}">Discover New</a></li>
                 <li class="active"><a href="//${configuration_helpers.get_value('CMS_BASE', '#')}">Studio</a></li>
                  % if user.is_staff or user.courseaccessrole_set.filter(role='role_manager').exists():
-                    <li ${'class="active"' if is_course_privileges  else ''}><a href="${reverse('colaraz_features:course-access-roles-list')}">Course Privileges</a></li>
+                    <li ${'class="active"' if is_course_privileges  else ''}><a href="//${lms_course_privileges_url}">Course Privileges</a></li>
                   % endif
               </ul>
             </div>


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-110](https://edlyio.atlassian.net/browse/COL-110)

**PR Description**
In this PR the course privileges link has been updated for studio site.

![image](https://user-images.githubusercontent.com/42294172/85016239-c65bef00-b182-11ea-8137-3ac1b2d580f6.png)
