### PR TITLE
COL-108 Add links to course titles in studio

### DIFF
--- a/colaraz/cms/templates/asset_index.html
+++ b/colaraz/cms/templates/asset_index.html
@@ -23,10 +23,13 @@
 
 <div class="wrapper-mast wrapper">
     <header class="mast has-actions has-subtitle">
+        <%
+          index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+        %>
         <h2 class="page-header">
             <small class="subtitle">${_("Content")} - ${_("Files & Uploads")}</small>
             <span class="sr">- </span>
-            <span class="text">${context_course.display_name_with_default}</span>
+            <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
         </h2>
     </header>
 </div>

--- a/colaraz/cms/templates/certificates.html
+++ b/colaraz/cms/templates/certificates.html
@@ -3,6 +3,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
 from contentstore import utils
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
@@ -49,10 +50,13 @@ CMS.User.isGlobalStaff = '${is_global_staff}'=='True' ? true : false;
 <%block name="content">
   <div class="wrapper-mast wrapper">
     <header class="mast has-actions has-subtitle">
+      <%
+        index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+      %>
       <h1 class="page-header">
         <small class="subtitle">${_("Settings")} - ${_("Certificates")}</small>
         <span class="sr">&gt; </span>
-        <span class="text">${context_course.display_name_with_default}</span>
+        <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
       </h1>
       <div class="preview-certificate nav-actions"></div>
     </header>

--- a/colaraz/cms/templates/checklists.html
+++ b/colaraz/cms/templates/checklists.html
@@ -26,10 +26,13 @@
 
 <div class="wrapper-mast wrapper">
     <header class="mast has-actions has-subtitle">
+        <%
+          index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+        %>
         <h2 class="page-header">
             <small class="subtitle">${_("Tools")} - ${_("Checklists")}</small>
             <span class="sr">- </span>
-            <span class="text">${context_course.display_name_with_default}</span>
+            <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
         </h2>
     </header>
 </div>

--- a/colaraz/cms/templates/container.html
+++ b/colaraz/cms/templates/container.html
@@ -1,0 +1,196 @@
+<%page expression_filter="h"/>
+<%inherit file="base.html" />
+<%def name="online_help_token()">
+<%
+if is_unit_page:
+    return "unit"
+else:
+    return "container"
+%>
+</%def>
+<%!
+from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext as _
+
+from contentstore.views.helpers import xblock_studio_url, xblock_type_display_name
+from openedx.core.djangolib.js_utils import (
+    dump_js_escaped_json, js_escaped_string
+)
+from openedx.core.djangolib.markup import HTML, Text
+%>
+
+<%block name="title">${xblock.display_name_with_default} ${xblock_type_display_name(xblock)}</%block>
+<%block name="bodyclass">is-signedin course container view-container</%block>
+
+<%namespace name='static' file='static_content.html'/>
+
+<%block name="header_extras">
+% for template_name in templates:
+<script type="text/template" id="${template_name}-tpl">
+    <%static:include path="js/${template_name}.underscore" />
+</script>
+% endfor
+<script type="text/template" id="image-modal-tpl">
+    <%static:include path="common/templates/image-modal.underscore" />
+</script>
+<link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
+% if not settings.STUDIO_FRONTEND_CONTAINER_URL:
+    <link rel="stylesheet" type="text/css" href="${static.url('common/css/vendor/common.min.css')}" />
+    <link rel="stylesheet" type="text/css" href="${static.url('common/css/vendor/editImageModal.min.css')}" />
+% endif
+</%block>
+
+<%block name="page_bundle">
+    <%static:webpack entry="js/factories/container">
+        ContainerFactory(
+            ${component_templates | n, dump_js_escaped_json},
+            ${xblock_info | n, dump_js_escaped_json},
+            "${action | n, js_escaped_string}",
+            {
+                isUnitPage: ${is_unit_page | n, dump_js_escaped_json},
+                canEdit: true,
+                outlineURL: "${outline_url | n, js_escaped_string}"
+            }
+        );
+    </%static:webpack>
+</%block>
+
+<%block name="content">
+
+<script type="text/javascript">
+    window.STUDIO_FRONTEND_IN_CONTEXT_IMAGE_SELECTION = true;
+</script>
+
+
+<div class="wrapper-mast wrapper">
+    <header class="mast has-actions has-navigation has-subtitle">
+        <%
+          index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+        %>
+        <div class="page-header">
+            <small class="navigation navigation-parents subtitle">
+                <a href="${index_url}" class="navigation-item navigation-link navigation-parent">${context_course.display_name_with_default}</a>
+                % for ancestor in ancestor_xblocks:
+                    <%
+                    ancestor_url = xblock_studio_url(ancestor)
+                    %>
+                    % if ancestor_url:
+                        <a href="${ancestor_url}" class="navigation-item navigation-link navigation-parent">${ancestor.display_name_with_default}</a>
+                    % else:
+                        <span class="navigation-item navigation-parent">${ancestor.display_name_with_default}</span>
+                    % endif
+                % endfor
+            </small>
+            <div class="wrapper-xblock-field incontext-editor is-editable"
+                 data-field="display_name" data-field-display-name="${_("Display Name")}">
+                <h1 class="page-header-title xblock-field-value incontext-editor-value"><span class="title-value">${xblock.display_name_with_default}</span></h1>
+            </div>
+            <div class="container-access">
+            </div>
+        </div>
+
+        <nav class="nav-actions" aria-label="${_('Page Actions')}">
+            <h3 class="sr">${_("Page Actions")}</h3>
+            <ul>
+                % if is_unit_page:
+                    <li class="action-item action-view nav-item">
+                        <a href="${published_preview_link}" class="button button-view action-button is-disabled" aria-disabled="true" rel="external" title="${_('Open the courseware in the LMS')}">
+                            <span class="action-button-text">${_("View Live Version")}</span>
+                        </a>
+                    </li>
+                    <li class="action-item action-preview nav-item">
+                        <a href="${draft_preview_link}" class="button button-preview action-button" rel="external" title="${_('Preview the courseware in the LMS')}">
+                            <span class="action-button-text">${_("Preview")}</span>
+                        </a>
+                    </li>
+                % else:
+                    <li class="action-item action-edit nav-item">
+                        <a href="#" class="button button-edit action-button edit-button">
+                            <span class="icon fa fa-pencil" aria-hidden="true"></span>
+                            <span class="action-button-text">${_("Edit")}</span>
+                        </a>
+                    </li>
+                % endif
+            </ul>
+        </nav>
+    </header>
+</div>
+
+<div class="wrapper-content wrapper">
+    <div class="inner-wrapper">
+        <section class="content-area">
+
+            <article class="content-primary">
+                <div class="container-message wrapper-message"></div>
+                <section class="wrapper-xblock level-page is-hidden studio-xblock-wrapper" data-locator="${xblock_locator}" data-course-key="${xblock_locator.course_key}">
+                </section>
+                <div class="ui-loading">
+                    <p><span class="spin"><span class="icon fa fa-refresh" aria-hidden="true"></span></span> <span class="copy">${_("Loading")}</span></p>
+                </div>
+            </article>
+            <aside class="content-supplementary" role="complementary">
+                % if xblock.category == 'split_test':
+                    <div class="bit">
+                        <h3 class="title-3">${_("Adding components")}</h3>
+                        <p>${Text(_("Select a component type under {strong_start}Add New Component{strong_end}. Then select a template.")).format(
+                                    strong_start=HTML('<strong>'),
+                                    strong_end=HTML("</strong>"),
+                            )}</p>
+                        <p>${_("The new component is added at the bottom of the page or group. You can then edit and move the component.")}</p>
+                        <h3 class="title-3">${_("Editing components")}</h3>
+                        <p>${Text(_("Click the {strong_start}Edit{strong_end} icon in a component to edit its content.")).format(
+                                    strong_start=HTML('<strong>'),
+                                    strong_end=HTML("</strong>"),
+                            )}</p>
+                        <h3 class="title-3">${_("Reorganizing components")}</h3>
+                        <p>${_("Drag components to new locations within this component.")}</p>
+                        <p>${_("For content experiments, you can drag components to other groups.")}</p>
+                        <h3 class="title-3">${_("Working with content experiments")}</h3>
+                        <p>${_("Confirm that you have properly configured content in each of your experiment groups.")}</p>
+                    </div>
+                    <div class="bit external-help">
+                        <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about component containers")}</a>
+                    </div>
+                % elif is_unit_page:
+                    <div id="publish-unit"></div>
+                    <div id="publish-history" class="unit-publish-history"></div>
+                    <div class="unit-location is-hidden">
+                        <h4 class="bar-mod-title">${_("Unit Location")}</h4>
+                        <div class="wrapper-unit-id bar-mod-content">
+                            <h5 class="title">${_("Location ID")}</h5>
+                            <p class="unit-id">
+                                <span class="unit-id-value" id="unit-location-id-input">${unit.location.block_id}</span>
+                                <span class="tip"><span class="sr">Tip: </span>${_('To create a link to this unit from an HTML component in this course, enter "/jump_to_id/<location ID>" as the URL value.')}</span>
+                            </p>
+                        </div>
+                        <div class="wrapper-unit-tree-location bar-mod-content">
+                            <h5 class="title">${_("Location in Course Outline")}</h5>
+                            <div class="wrapper-unit-overview outline outline-simple">
+                            </div>
+                        </div>
+                    </div>
+                % endif
+            </aside>
+        </section>
+        <div id="edit-image-modal">
+        <%static:studiofrontend entry="editImageModal">
+            {
+            "course": {
+                "id": "${context_course.id | n, js_escaped_string}",
+                "name": "${context_course.display_name_with_default | n, js_escaped_string}",
+                "url_name": "${context_course.location.name | n, js_escaped_string}",
+                "org": "${context_course.location.org | n, js_escaped_string}",
+                "num": "${context_course.location.course | n, js_escaped_string}",
+                "display_course_number": "${context_course.display_coursenumber | n, js_escaped_string}",
+                "revision": "${context_course.location.revision | n, js_escaped_string}"
+            },
+            "help_tokens": {
+                "image_accessibility": "${get_online_help_info('image_accessibility')['doc_url'] | n, js_escaped_string}"
+            },
+            "lang": "${language_code | n, js_escaped_string}"
+            }
+        </%static:studiofrontend>
+        </div>
+    </div>
+</div>
+</%block>

--- a/colaraz/cms/templates/course_info.html
+++ b/colaraz/cms/templates/course_info.html
@@ -3,6 +3,7 @@
 <%def name="online_help_token()"><% return "updates" %></%def>
 <%namespace name='static' file='static_content.html'/>
 <%!
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
@@ -37,9 +38,12 @@ from openedx.core.djangolib.js_utils import (
   <div class="wrapper-mast wrapper">
     <header class="mast has-actions has-subtitle">
       <h1 class="page-header">
+        <%
+          index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+        %>
         <small class="subtitle">${_("Content")} - ${_("Course Updates")}</small>
         <span class="sr">&gt; </span>
-        <span class="text">${context_course.display_name_with_default}</span>
+        <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
       </h1>
 
       <nav class="nav-actions" aria-label="${_('Page Actions')}">

--- a/colaraz/cms/templates/course_outline.html
+++ b/colaraz/cms/templates/course_outline.html
@@ -121,9 +121,8 @@ from django.core.urlresolvers import reverse
         <h1 class="page-header">
             <small class="subtitle">${_("Content")} - ${_("Course Outline")}</small>
             <span class="sr">&gt; </span>
-            <span class="text">${context_course.display_name_with_default}</span>
+            <a href="#"><span class="text">${context_course.display_name_with_default}</span></a>
         </h1>
-
         <nav class="nav-actions" aria-label="${_('Page Actions')}">
             <h3 class="sr">${_("Page Actions")}</h3>
             <ul>
@@ -165,7 +164,7 @@ from django.core.urlresolvers import reverse
                     <div style="width: 50%" class="status-studio-frontend">
                 % endif
                     <%static:studiofrontend entry="courseOutlineHealthCheck">
-                        <% 
+                        <%
                             course_key = context_course.id
                         %>
                         {
@@ -189,7 +188,7 @@ from django.core.urlresolvers import reverse
                                 "settings": ${reverse('settings_handler', kwargs={'course_key_string': unicode(course_key)})| n, dump_js_escaped_json}
                             }
                         }
-                    </%static:studiofrontend> 
+                    </%static:studiofrontend>
                 </div>
                 <div class="status-highlights-enabled"></div>
             </div>

--- a/colaraz/cms/templates/edit-tabs.html
+++ b/colaraz/cms/templates/edit-tabs.html
@@ -28,11 +28,15 @@
 <%block name="content">
 <div class="wrapper-mast wrapper">
   <header class="mast has-actions has-subtitle">
+    <%
+      index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+    %>
+
     <h1 class="page-header">
       <small class="subtitle">${_("Content")} - ${_("Pages")}</small>
       ## Translators: Pages refer to the tabs that appear in the top navigation of each course.
       <span class="sr"> > </span>
-      <span class="text">${context_course.display_name_with_default}</span>
+      <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
     </h1>
 
     <nav class="nav-actions" aria-label="${_('Page Actions')}">

--- a/colaraz/cms/templates/export.html
+++ b/colaraz/cms/templates/export.html
@@ -11,6 +11,7 @@ else:
 <%namespace name='static' file='static_content.html'/>
 
 <%!
+  from django.core.urlresolvers import reverse
   from django.utils.translation import ugettext as _
   from openedx.core.djangolib.markup import HTML, Text
   from openedx.core.djangolib.js_utils import (
@@ -39,6 +40,9 @@ else:
 <%block name="content">
 <div class="wrapper-mast wrapper">
   <header class="mast has-subtitle">
+    <%
+      index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+    %>
     <h1 class="page-header">
       <small class="subtitle">
         ${_("Tools")} -
@@ -49,7 +53,7 @@ else:
         %endif
       </small>
       <span class="sr">&gt; </span>
-      <span class="text">${context_course.display_name_with_default}</span>
+      <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
     </h1>
   </header>
 </div>

--- a/colaraz/cms/templates/group_configurations.html
+++ b/colaraz/cms/templates/group_configurations.html
@@ -6,6 +6,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
 from contentstore import utils
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
@@ -40,10 +41,14 @@ from openedx.core.djangolib.markup import HTML, Text
 <%block name="content">
   <div class="wrapper-mast wrapper">
     <header class="mast has-actions has-subtitle">
+      <%
+        index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+      %>
+
       <h1 class="page-header">
         <small class="subtitle">${_("Settings")} - ${_("Group Configurations")}</small>
         <span class="sr">&gt; </span>
-        <span class="text">${context_course.display_name_with_default}</span>
+        <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
       </h1>
     </header>
   </div>

--- a/colaraz/cms/templates/import.html
+++ b/colaraz/cms/templates/import.html
@@ -10,6 +10,7 @@ else:
 </%def>
 <%namespace name='static' file='static_content.html'/>
 <%!
+  from django.core.urlresolvers import reverse
   from django.utils.translation import ugettext as _
   from openedx.core.djangolib.js_utils import (
       dump_js_escaped_json, js_escaped_string
@@ -28,9 +29,12 @@ else:
 <%block name="content">
 <div class="wrapper-mast wrapper">
   <header class="mast has-subtitle">
+    <%
+      index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+    %>
     <h1 class="page-header">
       <small class="subtitle">
-        ${_("Tools")} - 
+        ${_("Tools")} -
         %if library:
             ${_("Library Import")}
         %else:
@@ -38,7 +42,7 @@ else:
         %endif
       </small>
       <span class="sr">&gt; </span>
-      <span class="text">${context_course.display_name_with_default}</span>
+      <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
     </h1>
   </header>
 </div>
@@ -258,4 +262,3 @@ else:
   Import('${import_status_url | n, js_escaped_string}', ${library | n, dump_js_escaped_json});
 </%static:webpack>
 </%block>
-

--- a/colaraz/cms/templates/manage_users.html
+++ b/colaraz/cms/templates/manage_users.html
@@ -22,10 +22,13 @@ from openedx.core.djangolib.js_utils import (
 
 <div class="wrapper-mast wrapper">
   <header class="mast has-actions has-subtitle">
+    <%
+      index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+    %>
     <h1 class="page-header">
       <small class="subtitle">${_("Settings")} - ${_("Course Team")}</small>
       <span class="sr">&gt; </span>
-      <span class="text">${context_course.display_name_with_default}</span>
+      <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
     </h1>
 
     <nav class="nav-actions" aria-label="${_('Page Actions')}">

--- a/colaraz/cms/templates/settings.html
+++ b/colaraz/cms/templates/settings.html
@@ -7,6 +7,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
   import urllib
+  from django.core.urlresolvers import reverse
   from django.utils.translation import ugettext as _
   from contentstore import utils
   from openedx.core.djangoapps.certificates.api import can_show_certificate_available_date_field
@@ -47,10 +48,13 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
 <%block name="content">
 <div class="wrapper-mast wrapper">
   <header class="mast has-subtitle">
+    <%
+      index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+    %>
     <h1 class="page-header">
       <small class="subtitle">${_("Settings")} - ${_("Schedule & Details")}</small>
       <span class="sr">&gt; </span>
-      <span class="text">${context_course.display_name_with_default}</span>
+      <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
     </h1>
   </header>
 </div>

--- a/colaraz/cms/templates/settings_advanced.html
+++ b/colaraz/cms/templates/settings_advanced.html
@@ -3,6 +3,7 @@
 <%def name="online_help_token()"><% return "advanced" %></%def>
 <%namespace name='static' file='static_content.html'/>
 <%!
+  from django.core.urlresolvers import reverse
   from django.utils.translation import ugettext as _
   from contentstore import utils
   from openedx.core.djangolib.js_utils import (
@@ -33,10 +34,13 @@
 <%block name="content">
 <div class="wrapper-mast wrapper">
   <header class="mast has-subtitle">
+    <%
+      index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+    %>
     <h1 class="page-header">
       <small class="subtitle">${_("Settings")} - ${_("Advanced Settings")}</small>
       <span class="sr">&gt; </span>
-      <span class="text">${context_course.display_name_with_default}</span>
+      <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
     </h1>
   </header>
 </div>

--- a/colaraz/cms/templates/settings_graders.html
+++ b/colaraz/cms/templates/settings_graders.html
@@ -7,6 +7,7 @@
 <%!
   import json
   from contentstore import utils
+  from django.core.urlresolvers import reverse
   from django.utils.translation import ugettext as _
   from models.settings.encoder import CourseSettingsEncoder
   from openedx.core.djangolib.js_utils import (
@@ -38,10 +39,13 @@
 <%block name="content">
 <div class="wrapper-mast wrapper">
   <header class="mast has-subtitle">
+    <%
+      index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+    %>
     <h1 class="page-header">
       <small class="subtitle">${_("Settings")} - ${_("Grading")}</small>
       <span class="sr">&gt; </span>
-      <span class="text">${context_course.display_name_with_default}</span>
+      <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
     </h1>
   </header>
 </div>

--- a/colaraz/cms/templates/textbooks.html
+++ b/colaraz/cms/templates/textbooks.html
@@ -2,6 +2,7 @@
 <%def name="online_help_token()"><% return "textbooks" %></%def>
 <%namespace name='static' file='static_content.html'/>
 <%!
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 %>
@@ -36,10 +37,13 @@ CMS.URL.LMS_BASE = "${settings.LMS_BASE}"
 <%block name="content">
   <div class="wrapper-mast wrapper">
     <header class="mast has-actions has-subtitle">
+      <%
+          index_url = reverse('course_handler', kwargs={'course_key_string': unicode(context_course.id)})
+      %>
       <h1 class="page-header">
         <small class="subtitle">${_("Content")} - ${_("Textbooks")}</small>
         <span class="sr">&gt; </span>
-        <span class="text">${context_course.display_name_with_default}</span>
+        <a href="${index_url}"><span class="text">${context_course.display_name_with_default}</span></a>
       </h1>
 
       <nav class="nav-actions" aria-label="${_('Page Actions')}">

--- a/colaraz/cms/templates/widgets/header.html
+++ b/colaraz/cms/templates/widgets/header.html
@@ -129,11 +129,11 @@
       % if user.is_authenticated:
       <%
         protocol = getattr(settings, 'COLARAZ_DOMAIN_PROTOCOL', 'http')
-        identifier = user.colaraz_profile.site_identifier 
+        identifier = user.colaraz_profile.site_identifier
         domain = settings.COLARAZ_SUB_DOMAIN
         user_urls = user.colaraz_profile.role_based_urls
         colaraz_notifications_url = user_urls.get('viewNotifications') if user_urls.has_key('viewNotifications') else '#'
-        
+
         invite_friend_url = '{}://{}.{}/Home/InviteFriends.aspx'.format( protocol, identifier, domain)
         see_all_notifications_url = '{}://{}.{}/{}'.format( protocol, identifier, domain, colaraz_notifications_url)
       %>
@@ -147,7 +147,7 @@
             <div class="header-dropdown dropdown-menu dropdown-menu-right all-notifications">
               <h4 class="notifications-heading">Notifications</h4>
               <ul id="notifications-list" class="notifications-list">
-                
+
               </ul>
               <div class="button-box">
                 <a href="${see_all_notifications_url}" class="btn btn-primary btn-see-all">see all</a>
@@ -200,7 +200,7 @@
     </div>
   </header>
     % if user.is_authenticated:
-      <% 
+      <%
         colaraz_ecosystem_url = '{}://{}.{}/cvsocial/activity?{}'.format(protocol, identifier, domain, user_urls.get('ecosystem')) if user_urls.has_key('ecosystem') else '#'
         colaraz_recruiting_url = '{}://{}.{}/{}'.format(protocol, identifier, domain, user_urls.get('recruiting')) if user_urls.has_key('recruiting') else '#'
         colaraz_management_url = '{}://{}.{}/{}'.format(protocol, identifier, domain, user_urls.get('management')) if user_urls.has_key('management') else '#'
@@ -227,7 +227,7 @@
                   <li><a href="${colaraz_ecosystem_url}"><span class="ecosystem-link"></span>Ecosystem</a></li>
                     <li><a href="${colaraz_recruiting_url}"><span class="recruiting-link"></span>Recruiting</a></li>
                     <li><a href="${colaraz_management_url}"><span class="projects-link"></span>Management</a></li>
-                    
+
                     % if configuration_helpers.get_value('COMPANY_TYPE') == 'enterprise plus':
                         <li><a href="${colaraz_performance_url}"><span class="talent-link"></span>Performance</a></li>
                     % endif


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-108](https://edlyio.atlassian.net/browse/COL-108)

**PR Description**
In this PR the `anchor` tags have been added to Course titles shown on the studio site. A link to the course outline has also been added in the bread crumb which is shown on a single `Unit` page.

**Linked course title on settings page**
![image](https://user-images.githubusercontent.com/42294172/85653215-35c36880-b6c6-11ea-979f-2d28e83a6454.png)

**Note:** The similar linked course title will be shown on 
1. `Updates`
2. `Pages`
3. `File & Uploads`
4. `Textbooks`
5. `Schedule & Details`
6. `Grading`
7. `Course team`
8. `Group Configuration`
9. `Advance settings`
10. `Certificates`
11. `Import`
12. `Export` 
13. `Checklists` webpages.

**Linked course title in the bread crumb**
![image](https://user-images.githubusercontent.com/42294172/85653367-660b0700-b6c6-11ea-9da0-d6c6f613e2f7.png)
