### PR TITLE
COL-151 Fix maximum file size error message from the footter in studio

### DIFF
--- a/colaraz/cms/templates/base.html
+++ b/colaraz/cms/templates/base.html
@@ -265,5 +265,11 @@ from openedx.core.release import RELEASE_LINE
     <%include file="widgets/segment-io-footer.html" />
     <script type="text/javascript" src="${static.url('js/header.js')}"></script>
     <div class="modal-cover"></div>
+    <script>
+      $('#page-notification').bind('DOMSubtreeModified', function () {
+        if ($(this).text().includes('exceeds maximum size of')) {
+          setTimeout(function() { $('#page-notification').empty(); }, 3000);
+        }});
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-151](https://edlyio.atlassian.net/browse/COL-151)

**PR Description**
Previously, when we uploaded a `textbook` having a size more than the allowed size, the error message appeared at the bottom of the screen and never disappeared unless the user refreshed the page. This behavior has been removed in this PR. Now the error message will be removed after 3 seconds.


![image](https://user-images.githubusercontent.com/42294172/86138704-3a45b200-bb08-11ea-8363-765ce419bedb.png)
