### PR TITLE
COL-155 Fix unenrollment button issue when certificates is achieved

### DIFF
--- a/colaraz/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/colaraz/lms/templates/dashboard/_dashboard_course_listing.html
@@ -278,7 +278,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
             ## as these are the only actions currently available
             % if entitlement and (can_refund_entitlement or show_email_settings):
                 <%include file='_dashboard_entitlement_actions.html' args='course_overview=course_overview,entitlement=entitlement,dashboard_index=dashboard_index, can_refund_entitlement=can_refund_entitlement, show_email_settings=show_email_settings'/>
-            % elif not entitlement:
+            % elif not entitlement and (can_unenroll or show_email_settings):
                 <div class="wrapper-action-more" data-course-key="${enrollment.course_id}">
                   <button type="button" class="action action-more" id="actions-dropdown-link-${dashboard_index}" aria-haspopup="true" aria-expanded="false" aria-controls="actions-dropdown-${dashboard_index}" data-course-number="${course_overview.number}" data-course-name="${course_overview.display_name_with_default}" data-dashboard-index="${dashboard_index}">
                     <span class="sr">${_('Course options for')}</span>


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-155](https://edlyio.atlassian.net/browse/COL-155)

**PR Description**
When we have got a certificate for a course, the `unenroll` button should be hidden from the user. In this PR this feature has been added.


**Default Behavior**
![image](https://user-images.githubusercontent.com/42294172/86340041-c9200f00-bc6d-11ea-9483-4853fdc07759.png)
