### PR TITLE
Adding user fullname in window object

### DIFF
--- a/colaraz/lms/templates/main.html
+++ b/colaraz/lms/templates/main.html
@@ -102,6 +102,9 @@
     % endif
     <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
     <script type="text/javascript" src="${static.url(ie11_fix_path)}"></script>
+    <script type="text/javascript">
+        window.user_full_name = "${user.profile.name}";
+    </script>
 
     <link rel="icon" type="image/x-icon" href="${static.url(static.get_value('favicon_path', settings.FAVICON_PATH))}"/>
 


### PR DESCRIPTION
### Story Link
https://edlyio.atlassian.net/browse/COL-157

### Description
In Colaraz, User's username field isn't being used to show User's name, we are using UserProfile's Name field instead. So, for that reason we have to add UserProfile's name in window object to be used in discussion filters.