### PR TITLE
Syncing login with ecosystem

### DIFF
--- a/colaraz/cms/static/js/header.js
+++ b/colaraz/cms/static/js/header.js
@@ -196,3 +196,16 @@ function removeJobAlertsCount() {
         markJobAlertsAsRead();
     }
 }
+
+function loginToEcosystem(ecosystemUrl) {
+    // TODO: It's just a temporary fix, COLARAZ needs to fix this issue on their end.
+    let iframe = $('#ecosystem-iframe');
+    if (iframe.children().length === 0) {
+        iframe.append(`<iframe src="${ecosystemUrl}"></iframe>`)
+    }
+}
+
+function notificationsIconClick(ecosystemUrl){
+    removeNotificationsCount(); 
+    loginToEcosystem(ecosystemUrl);
+}

--- a/colaraz/cms/templates/widgets/header.html
+++ b/colaraz/cms/templates/widgets/header.html
@@ -134,14 +134,16 @@
         user_urls = user.colaraz_profile.role_based_urls
         colaraz_notifications_url = user_urls.get('viewNotifications') if user_urls.has_key('viewNotifications') else '#'
 
-        invite_friend_url = '{}://{}.{}/Home/InviteFriends.aspx'.format( protocol, identifier, domain)
+        invite_friend_url = '{}://{}.{}/{}'.format(protocol, identifier, domain, user_urls.get('inviteFriend', '#'))
         see_all_notifications_url = '{}://{}.{}/{}'.format( protocol, identifier, domain, colaraz_notifications_url)
+        colaraz_ecosystem_url = '{}://{}.{}/cvsocial/activity?{}'.format(protocol, identifier, domain, user_urls.get('ecosystem', '#'))
+        
       %>
       <nav class="nav-account nav-is-signedin nav-dd ui-right" aria-label="${_('Account')}">
         <h2 class="sr-only">${_("Account Navigation")}</h2>
         <ol>
           <li class="dropdown">
-            <a class="nav-link" href="#" onclick="removeNotificationsCount();" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <a class="nav-link" href="#" onclick="notificationsIconClick('${colaraz_ecosystem_url}');" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <span class="fa fa-globe" aria-hidden="true"></span><span id="unread-notifications-count" class=""></span>
             </a>
             <div class="header-dropdown dropdown-menu dropdown-menu-right all-notifications">
@@ -149,6 +151,7 @@
               <ul id="notifications-list" class="notifications-list">
 
               </ul>
+              <div id="ecosystem-iframe" style="display: none;"></div>
               <div class="button-box">
                 <a href="${see_all_notifications_url}" class="btn btn-primary btn-see-all">see all</a>
               </div>

--- a/colaraz/lms/static/js/header/header.js
+++ b/colaraz/lms/static/js/header/header.js
@@ -543,3 +543,16 @@ function removeJobAlertsCount() {
         markJobAlertsAsRead();
     }
 }
+
+function loginToEcosystem(ecosystemUrl){
+    // TODO: It's just a temporary fix, COLARAZ needs to fix this issue on their end.
+    let iframe = $('#ecosystem-iframe');
+    if (iframe.children().length === 0){
+        iframe.append(`<iframe src="${ecosystemUrl}"></iframe>`)
+    }
+}
+
+function notificationsIconClick(ecosystemUrl) {
+    removeNotificationsCount();
+    loginToEcosystem(ecosystemUrl);
+}

--- a/colaraz/lms/templates/header/navbar-authenticated.html
+++ b/colaraz/lms/templates/header/navbar-authenticated.html
@@ -22,6 +22,7 @@
   if user.is_authenticated:
     invite_friend_url = '{}://{}.{}/{}'.format(protocol, identifier, sub_domain, user_urls.get('inviteFriend', '#'))
     see_all_notifications_url = '{}://{}.{}/{}'.format(protocol, identifier, sub_domain, user_urls.get('viewNotifications', '#'))
+    colaraz_ecosystem_url = '{}://{}.{}/cvsocial/activity?{}'.format(protocol, identifier, sub_domain, user_urls.get('ecosystem', '#'))
   endif
 %>
 
@@ -63,13 +64,14 @@
   <div id="edly-nav-menu" class="main-navigation">
     <ul class="custom-nav mobile-nav-item">
       <li class="dropdown notification-li">
-        <a class="nav-item" href="#" onclick="removeNotificationsCount();" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <a class="nav-item" href="#" onclick="notificationsIconClick('${colaraz_ecosystem_url}');" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <span class="fa fa-globe" aria-hidden="true"></span><span id="unread-notifications-count" class=""></span>
         </a>
         <div class="header-dropdown dropdown-menu dropdown-menu-right all-notifications" x-placement="bottom-end">
           <h4 class="notifications-heading">Notifications</h4>
           <ul id="notifications-list" class="notifications-list">
           </ul>
+          <div id="ecosystem-iframe" style="display: none;"></div>
           <div class="button-box">
             <a href="${see_all_notifications_url}" class="btn btn-primary btn-see-all">See all</a>
           </div>


### PR DESCRIPTION
### Story Link
https://edlyio.atlassian.net/browse/COL-145
### Description
Colaraz IdP isn't able to login users on their ecosystem site and requires a specific query string for authentication. So we are handling this on our side temporarily.
Whenever a user clicks on the Notification Icon in the navbar, the system will open an iframe to get the user logged in onto the ecosystem site. The system will also check if an iframe is already opened or not, to save unnecessary hits.