### PR TITLE
COL-188 Remove username word from certificates tab

### DIFF
--- a/colaraz/lms/static/sass/course/layout/_course-instructor-tab.scss
+++ b/colaraz/lms/static/sass/course/layout/_course-instructor-tab.scss
@@ -226,3 +226,7 @@
         padding: $baseline*0.5 0;
     }
 }
+
+.certificate-invalidation-user-label{
+    margin-right: 100px;
+}

--- a/colaraz/lms/templates/instructor/instructor_dashboard_2/certificate-bulk-white-list.underscore
+++ b/colaraz/lms/templates/instructor/instructor_dashboard_2/certificate-bulk-white-list.underscore
@@ -1,0 +1,18 @@
+<h3 class="hd hd-3"><%- gettext("Bulk Exceptions") %></h3>
+<div class="white-list-csv">
+    <p class="under-heading">
+     <%- gettext("Upload a comma separated values (.csv) file that contains the email addresses of learners who have been given exceptions. Include the email address in the first comma separated field. You can include an optional note describing the reason for the exception in the second comma separated field.") %>
+    </p>
+    <form id="bulk-white-list-exception-form" enctype="multipart/form-data">
+        <div class="customBrowseBtn">
+            <label for="browseBtn-bulk-csv"><%- gettext("Upload a CSV file") %></label>
+            <span class="browse-file enhanced-input-file" id="bulk-exception-upload"></span>
+            <div class="file-browse btn btn-primary" aria-hidden="true">
+                <span class="browse"><%- gettext("Browse") %></span>
+                <input class="file_field" id="browseBtn-bulk-csv" name="students_list" type="file" accept=".csv"/>
+            </div>
+        </div>
+        <button type="submit" class="btn-blue upload-csv-button"><%- gettext("Add to Exception List") %></button>
+    </form>
+    <div class="bulk-exception-results hidden"></div>
+</div>

--- a/colaraz/lms/templates/instructor/instructor_dashboard_2/certificate-invalidation.underscore
+++ b/colaraz/lms/templates/instructor/instructor_dashboard_2/certificate-invalidation.underscore
@@ -4,7 +4,7 @@
 
 <div class="add-certificate-invalidation">
     <div>
-        <label for="certificate-invalidation-user"><%- gettext('Email address') %></label>
+        <label class="certificate-invalidation-user-label" for="certificate-invalidation-user"><%- gettext('Email address') %></label>
         <input class="student-username-or-email" id="certificate-invalidation-user" type="text">
     </div>
     <div>

--- a/colaraz/lms/templates/instructor/instructor_dashboard_2/certificate-invalidation.underscore
+++ b/colaraz/lms/templates/instructor/instructor_dashboard_2/certificate-invalidation.underscore
@@ -1,0 +1,50 @@
+<p class="under-heading info">
+ <%- gettext("To invalidate a certificate for a particular learner, add the email address below.") %>
+</p>
+
+<div class="add-certificate-invalidation">
+    <div>
+        <label for="certificate-invalidation-user"><%- gettext('Email address') %></label>
+        <input class="student-username-or-email" id="certificate-invalidation-user" type="text">
+    </div>
+    <div>
+        <label for="certificate-invalidation-notes"><%- gettext('Add notes about this learner') %></label>
+        <textarea class="notes-field" id="certificate-invalidation-notes" rows="10"></textarea>
+    </div>
+    <br/>
+
+    <button type="button" class="btn-blue" id="invalidate-certificate"><%- gettext('Invalidate Certificate') %></button>
+</div>
+
+<div class="message hidden"></div>
+
+<div class="invalidation-history">
+    <% if (certificate_invalidations.length === 0) { %>
+        <p><%- gettext("No results") %></p>
+    <% } else { %>
+        <table>
+            <thead>
+                <tr>
+                    <th class='user-name'><%- gettext('Student') %></th>
+                    <th class='user-name'><%- gettext('Invalidated By') %></th>
+                    <th class='date'><%- gettext('Invalidated') %></th>
+                    <th class='notes'><%- gettext('Notes') %></th>
+                    <th class='action'><%- gettext('Action') %></th>
+                </tr>
+            </thead>
+            <tbody>
+                <% for (var i = 0; i < certificate_invalidations.length; i++) {
+                    var certificate_invalidation = certificate_invalidations[i];
+                %>
+                <tr>
+                    <td><%- certificate_invalidation.get("user") %></td>
+                    <td><%- certificate_invalidation.get("invalidated_by") %></td>
+                    <td><%- certificate_invalidation.get("created") %></td>
+                    <td><%- certificate_invalidation.get("notes") %></td>
+                    <td><button class='re-validate-certificate' data-cid='<%- certificate_invalidation.cid %>'><%- gettext("Remove from Invalidation Table") %></button></td>
+                </tr>
+                <% } %>
+            </tbody>
+        </table>
+    <% } %>
+</div>

--- a/colaraz/lms/templates/instructor/instructor_dashboard_2/certificate-white-list-editor.underscore
+++ b/colaraz/lms/templates/instructor/instructor_dashboard_2/certificate-white-list-editor.underscore
@@ -1,0 +1,15 @@
+<h3 class="hd hd-3"><%- gettext("Individual Exceptions") %></h3>
+<p class="under-heading"> <%- gettext("Enter the email address of each learner that you want to add as an exception.") %></p>
+<div class='certificate-exception-inputs'>
+    <div class="">
+        <label for="certificate-exception" class="sr"><%- gettext("Student email address") %></label>
+        <input class="student-username-or-email" id="certificate-exception" type="text" placeholder="<%- gettext('Student email address') %>">
+
+        <label for="notes" class="sr"><%- gettext('Free text notes') %></label>
+        <textarea class="notes-field" id="notes" rows="10" placeholder="<%- gettext('Free text notes') %>"></textarea>
+    </div>
+    <div>
+        <button type="button" class="btn-blue" id="add-exception"><%- gettext("Add to Exception List") %></button>
+    </div>
+    <div class='message hidden'></div>
+</div>


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-188](https://edlyio.atlassian.net/browse/COL-188)

**PR Description**
Previously, when we removed the username from the instructor dashboard, the certificates weren't enabled that's why we missed this page. Now the certificates page has also been updated.

**Related PR**
[https://github.com/colaraz/edx-platform/pull/105](https://github.com/colaraz/edx-platform/pull/105)