### PR TITLE
COL-161 Add organization dropdown for library creation

### DIFF
--- a/colaraz/cms/static/sass/shared-v2/_dashboard.scss
+++ b/colaraz/cms/static/sass/shared-v2/_dashboard.scss
@@ -139,3 +139,7 @@
         }
     }
 }
+
+.new-library-org {
+    width: 100%;
+}

--- a/colaraz/cms/templates/index.html
+++ b/colaraz/cms/templates/index.html
@@ -169,7 +169,9 @@ from openedx.core.djangolib.js_utils import (
                 </li>
                 <li class="field text required">
                   <label for="new-library-org">${_("Organization")}</label>
-                  <input class="new-library-org" id="new-library-org" type="text" name="new-library-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-library-org tip-error-new-library-org" />
+                  <select class="new-library-org" id="new-library-org" type="text" name="new-library-org" required aria-describedby="tip-new-library-org tip-error-new-library-org">
+                    <option value="" selected >${_('Select the organization')}</option>
+                  </select>
                   <span class="tip" id="tip-new-library-org">${_("The public organization name for your library.")} ${_("This cannot be changed.")}</span>
                   <span class="tip tip-error is-hiding" id="tip-error-new-library-org"></span>
                 </li>


### PR DESCRIPTION
This PR is related to [https://edlyio.atlassian.net/browse/COL-161](https://edlyio.atlassian.net/browse/COL-161)

**PR Description**
In this PR the organization drop-down menu for content library has been added.

![image](https://user-images.githubusercontent.com/42294172/88820777-337b8f00-d1db-11ea-8da2-532269a43ead.png)


**Related PR**
[https://github.com/colaraz/edx-platform/pull/111](https://github.com/colaraz/edx-platform/pull/111)