### PR TITLE
Removed Finance link from header

### DIFF
--- a/colaraz/cms/templates/widgets/header.html
+++ b/colaraz/cms/templates/widgets/header.html
@@ -137,7 +137,7 @@
         invite_friend_url = '{}{}'.format(base_url, user_urls.get('inviteFriend', '#'))
         see_all_notifications_url = '{}{}'.format(base_url, colaraz_notifications_url)
         colaraz_ecosystem_url = '{}cvsocial/activity?{}'.format(base_url, user_urls.get('ecosystem', '#'))
-        
+
       %>
       <nav class="nav-account nav-is-signedin nav-dd ui-right" aria-label="${_('Account')}">
         <h2 class="sr-only">${_("Account Navigation")}</h2>
@@ -236,7 +236,8 @@
                         <li><a href="${colaraz_performance_url}"><span class="talent-link"></span>Performance</a></li>
                     % endif
                     <li class="active"><a href="${colaraz_development_url}"><span class="development-link"></span>Development</a></li>
-                    <li><a href="${colaraz_finance_url}"><span class="finance-link"></span>Finance</a></li>
+                    <!-- TODO: Temporary change. We will revert it later  -->
+                    <!-- <li><a href="${colaraz_finance_url}"><span class="finance-link"></span>Finance</a></li> -->
                 </ul>
             </div>
         </nav>

--- a/colaraz/lms/templates/header/header.html
+++ b/colaraz/lms/templates/header/header.html
@@ -77,9 +77,9 @@ from openedx.features.colaraz_features.models import ColarazUserProfile
     </div>
     <div class="mobile-menu hidden" aria-label=${_("More Options")} role="menu" id="mobile-menu"></div>
     % if user.is_authenticated:
-        <% 
+        <%
             protocol = getattr(settings, 'COLARAZ_DOMAIN_PROTOCOL', 'http')
-            identifier = user.colaraz_profile.site_identifier 
+            identifier = user.colaraz_profile.site_identifier
             domain = settings.COLARAZ_SUB_DOMAIN
             base_url = '{}://{}.{}/'.format(protocol, identifier, domain)
             user_urls = user.colaraz_profile.role_based_urls
@@ -111,12 +111,13 @@ from openedx.features.colaraz_features.models import ColarazUserProfile
                     <li><a href="${colaraz_ecosystem_url}"><span class="ecosystem-link"></span>Ecosystem</a></li>
                     <li><a href="${colaraz_recruiting_url}"><span class="recruiting-link"></span>Recruiting</a></li>
                     <li><a href="${colaraz_management_url}"><span class="projects-link"></span>Management</a></li>
-                    
+
                     % if configuration_helpers.get_value('COMPANY_TYPE') == 'enterprise plus':
                     <li><a href="${colaraz_performance_url}"><span class="talent-link"></span>Performance</a></li>
                     % endif
                     <li class="active"><a href="${colaraz_development_url}"><span class="development-link"></span>Development</a></li>
-                    <li><a href="${colaraz_finance_url}"><span class="finance-link"></span>Finance</a></li>
+                    <!-- TODO: Temporary change. We will revert it later  -->
+                    <!-- <li><a href="${colaraz_finance_url}"><span class="finance-link"></span>Finance</a></li> -->
                 </ul>
             </div>
         </nav>


### PR DESCRIPTION
**Removed Finance link from Header**

Story: [COL-275](https://edlyio.atlassian.net/browse/COL-275?atlOrigin=eyJpIjoiM2RiMWVhZGMwMmNiNDU4MjgyOGMxNjM4MTI2YmQzMzEiLCJwIjoiaiJ9)

**Description:**
Comment the 'Finance' link from header. It can still be viewed from Developer Tools. 

<img src="https://user-images.githubusercontent.com/71447999/108345177-cb84a880-71ff-11eb-9c7e-f6976487f6ca.jpg" width="700" height="450" />
